### PR TITLE
Add FASTA prediction script

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -1,0 +1,24 @@
+# Docker Usage
+
+This repository can be used inside a Docker container. The provided `Dockerfile` installs all Python dependencies listed in `requirements.txt` and copies the repository files into the image.
+
+## Build the image
+
+```bash
+docker build -t thermoters .
+```
+
+## Run the container
+
+To start an interactive Python session:
+
+```bash
+docker run -it thermoters
+```
+
+You can also mount the repository directory to keep changes outside the container:
+
+```bash
+docker run -it -v $(pwd):/app thermoters
+```
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.8-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python3"]

--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ __Abstract__
 Predicting gene expression levels from any DNA sequence is a major challenge in biology. Using libraries with >25,000 random mutants, we developed a biophysical model that accounts for major features of σ70-binding bacterial promoters to accurately predict constitutive gene expression levels of any sequence. We experimentally and theoretically estimated that 10-20% of random sequences lead to expression and 82% of non-expressing sequences are one point mutation away from a functional promoter. Generating expression from random sequences is pervasive, such that selection acts against σ70-RNA polymerase binding sites even within inter-genic, promoter-containing regions. The pervasiveness of σ70– binding sites, which arises from the structural features of promoters captured by our biophysical model, implies that their emergence is unlikely the limiting step in gene regulatory evolution.
 
 The research was conducted at the Institute of Science and Technology Austria, from 2015-2019. 
+
+## Predict promoter strength from FASTA
+
+Use the `predict_from_fasta.py` script to estimate promoter strength for each sequence in a FASTA file.
+
+```bash
+python predict_from_fasta.py your_sequences.fasta models/fitted_on_Pr/model_[4]_stm+flex+cumul+rbs+rc.dmp
+```
+
+The script outputs tab-separated pairs of sequence identifiers and predicted log10 promoter strength.
+

--- a/functions/review_functions.py
+++ b/functions/review_functions.py
@@ -8,7 +8,7 @@ def import_Zhou(
     ShineDelgarno_toll = 3,
     seq_length_toll = 3,
 ):
-    filename = "review_datasets/Data_for_Srdjan.xlsx"
+    filename = "datasets_dir/review_datasets/Data_for_Srdjan.xlsx"
     isheet = 4
     print(f"importing sheet no.{isheet} from {filename}")
     data = pd.read_excel(filename, sheet_name=isheet)
@@ -67,7 +67,7 @@ def import_Zhou(
 
 def import_Hossain():
     # shinedelgarno = "aggag"
-    data = pd.read_excel("review_datasets/Data_for_Srdjan.xlsx", sheet_name=0)
+    data = pd.read_excel("datasets_dir/review_datasets/Data_for_Srdjan.xlsx", sheet_name=0)
     data.columns = [c.lower() for c in data.columns]
     # data["promoter sequence"].apply(lambda xi: xi.find(shinedalgarno)).value_counts()
     # So, no Shine-Delgarno anywhere.
@@ -103,13 +103,13 @@ def import_Hossain():
 
 def import_Utrecho():
     
-    print ("Importing sheet 3 from review_datasets/Data_for_Srdjan.xlsx. That's where the sequence are.")
-    dataseq = pd.read_excel("review_datasets/Data_for_Srdjan.xlsx", sheet_name=3)
+    print ("Importing sheet 3 from datasets_dir/review_datasets/Data_for_Srdjan.xlsx. That's where the sequence are.")
+    dataseq = pd.read_excel("datasets_dir/review_datasets/Data_for_Srdjan.xlsx", sheet_name=3)
     print ("Dropping duplicates.")
     dataseq = dataseq.drop_duplicates()
 
-    print ("Importing expressions from review_datasets/GSE108535_sigma70_variant_data.txt")
-    dataexp = pd.read_csv("review_datasets/GSE108535_sigma70_variant_data.txt", sep=" ")
+    print ("Importing expressions from datasets_dir/review_datasets/GSE108535_sigma70_variant_data.txt")
+    dataexp = pd.read_csv("datasets_dir/review_datasets/GSE108535_sigma70_variant_data.txt", sep=" ")
     dataexp.name = [name.replace("_","-") for name in dataexp.name]
     print ("Merging the two.")
     data = dataexp.merge(dataseq, on="name")
@@ -127,8 +127,8 @@ def import_Utrecho():
 
 def import_Johns():
     
-    print ("Importing sheet 1 from review_datasets/Data_for_Srdjan.xlsx.")
-    data = pd.read_excel("review_datasets/Data_for_Srdjan.xlsx", sheet_name=1)
+    print ("Importing sheet 1 from datasets_dir/review_datasets/Data_for_Srdjan.xlsx.")
+    data = pd.read_excel("datasets_dir/review_datasets/Data_for_Srdjan.xlsx", sheet_name=1)
     data.columns = [c.strip() for c in data.columns] 
     data.columns = [c.lower() for c in data.columns]
     select = np.isfinite(data['expression in m9'])

--- a/predict_from_fasta.py
+++ b/predict_from_fasta.py
@@ -1,0 +1,62 @@
+import argparse
+import pickle
+from collections import Counter
+from pathlib import Path
+
+from Bio import SeqIO
+import numpy as np
+
+from functions.other_datasets_porting import dict2tdm
+
+BASEMAP = {'a': 0, 'c': 1, 'g': 2, 't': 3}
+
+
+def numerize_sequences(sequences, length=115, pad='a'):
+    """Convert sequences to numeric arrays accepted by the model."""
+    lengths = [len(s) for s in sequences]
+    most_common = Counter(lengths).most_common(1)[0][0]
+    arr = np.zeros((len(sequences), length), dtype=np.int8)
+    for idx, seq in enumerate(sequences):
+        if len(seq) < most_common:
+            seq = pad * (most_common - len(seq)) + seq
+        arr[idx] = [BASEMAP.get(b, 0) for b in seq.lower()[:length]]
+    return arr
+
+
+def predict(fasta_path, model_path, treat_as='36N', length=115):
+    """Return log10 promoter strengths for sequences in FASTA."""
+    records = list(SeqIO.parse(fasta_path, 'fasta'))
+    seqs = [str(r.seq) for r in records]
+    names = [r.id for r in records]
+
+    with open(model_path, 'rb') as fh:
+        model_dict = pickle.load(fh)
+    tdm = dict2tdm(model_dict, treat_as=treat_as)
+
+    num = numerize_sequences(seqs, length=length)
+    bricks = tdm.sequences2bricks(num)
+    pons = tdm.bricks2pons(bricks)
+    return list(zip(names, np.log10(pons)))
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Predict promoter strength from FASTA sequences.')
+    parser.add_argument('fasta', help='Input FASTA file')
+    parser.add_argument('model', help='Pickle file containing model parameters')
+    parser.add_argument('--treat-as', default='36N', help='Dataset key inside the model file')
+    parser.add_argument('--length', type=int, default=115, help='Sequence length for numerization')
+    parser.add_argument('--output', type=Path, help='Optional output file to write predictions')
+    args = parser.parse_args()
+
+    results = predict(args.fasta, args.model, args.treat_as, args.length)
+
+    out_lines = [f"{name}\t{strength:.4f}" for name, strength in results]
+    if args.output:
+        args.output.write_text("\n".join(out_lines))
+    else:
+        for line in out_lines:
+            print(line)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- move `review_datasets` into `datasets_dir`
- adjust paths in `review_functions.py`
- add `predict_from_fasta.py` to predict promoter strength for FASTA sequences
- document script usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684689b31dd0832e8ffa2195166e4e5c